### PR TITLE
Make make targets phony

### DIFF
--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -7,3 +7,4 @@ localecompile:
 localegen:
 	django-admin makemessages -i build -i dist -i "*egg*" $(LNGS)
 
+.PHONY: all localecompile localegen


### PR DESCRIPTION
Hi,

according to the official [make manual](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html) targets that are not a filename of a file they might produce are phony and should be marked as such in order to prevent unwanted behaviour in case a file with the name of a target is present.

Cheers, 8sq