### PR TITLE
Add GitHub workflow for style checks

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/style.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/style.yml
@@ -1,0 +1,130 @@
+name: Code Style
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '{{cookiecutter.module_name}}/locale/**'
+      - '{{cookiecutter.module_name}}/static/**'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '{{cookiecutter.module_name}}/locale/**'
+      - '{{cookiecutter.module_name}}/static/**'
+
+jobs:
+  isort:
+    name: isort
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install pretix
+        run: pip3 install pretix
+      - name: Install Dependencies
+        run: pip3 install isort -Ue .
+      - name: Run isort
+        run: isort -c .
+  flake:
+    name: flake8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install pretix
+        run: pip3 install pretix
+      - name: Install Dependencies
+        run: pip3 install flake8 -Ue .
+      - name: Run flake8
+        run: flake8 .
+        working-directory: .
+  black:
+    name: black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install pretix
+        run: pip3 install pretix
+      - name: Install Dependencies
+        run: pip3 install black -Ue .
+      - name: Run black
+        run: black --check .
+        working-directory: .
+  docformatter:
+    name: docformatter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install pretix
+        run: pip3 install pretix
+      - name: Install Dependencies
+        run: pip3 install docformatter -Ue .
+      - name: Run docformatter
+        run: docformatter --check -r .
+        working-directory: .
+  packaging:
+    name: packaging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install pretix
+        run: pip3 install pretix
+      - name: Install Dependencies
+        run: pip3 install twine check-manifest -Ue .
+      - name: Run check-manifest
+        run: check-manifest .
+        working-directory: .
+      - name: Build package
+        run: python setup.py sdist
+        working-directory: .
+      - name: Check package
+        run: twine check dist/*
+        working-directory: .


### PR DESCRIPTION
The [Plugin quality checklist](https://docs.pretix.eu/en/latest/development/api/quality.html) says

> Continuous Integration is set up to check that tests are passing and styling is consistent.

Setting up plugin tests via CI is a bit tricky, so I've started with setting up style checks. They pretty much follow the pretix style check workflow. You can see it in action [here](https://github.com/rixx/pretix-limit-phone-country/actions).

I know that pretix-plugin-cookiecutter is not GitHub-specific and not even git-specific, but I'd wager that a majority of plugins are hosted on GitHub, and so this could be an easy way to add code checks to all new plugins.